### PR TITLE
スクラップ一覧/詳細機能の実装

### DIFF
--- a/app/controllers/scraps_controller.rb
+++ b/app/controllers/scraps_controller.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class ScrapsController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: [:show]
+  def show
+    @scrap = Scrap.find_by(id: params[:id])
+  end
+
   def new
     @scrap = Scrap.new
   end

--- a/app/controllers/scraps_controller.rb
+++ b/app/controllers/scraps_controller.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 class ScrapsController < ApplicationController
-  before_action :authenticate_user!, except: [:show]
+  before_action :authenticate_user!, except: %i[show index]
+
+  def index
+    @scraps = Scrap.limit(10).order(created_at: :desc)
+  end
+
   def show
     @scrap = Scrap.find_by(id: params[:id])
   end
@@ -15,7 +20,7 @@ class ScrapsController < ApplicationController
     @scrap.user_id = current_user.id
     if @scrap.save
       flash[:notice] = '記録しました'
-      redirect_to root_path
+      redirect_to scraps_path
     else
       flash[:alert] = '記録に失敗しました'
       render :new

--- a/app/views/scraps/index.html.erb
+++ b/app/views/scraps/index.html.erb
@@ -1,0 +1,20 @@
+<div class="space-y-6 w-3/4 max-w-lg">
+  <label class="block text-xl font-bold text-gray-700">学習ログ一覧</label>
+  <div class="items-center justify-center">
+    <% @scraps.each do |scrap| %>
+      <div tabindex="0" aria-label="card 1" class="focus:outline-none mb-7 bg-white p-6 shadow rounded">
+        <div class="flex items-center border-b border-gray-200 pb-6">
+          <div class="flex items-start justify-between w-full">
+            <div class="pl-3">
+              <p class="focus:outline-none text-lg font-medium leading-5 text-gray-800"><%= link_to scrap.title, scrap_path(scrap) %></p>
+              <p class="focus:outline-none text-sm leading-normal pt-2 text-gray-500">by <%= scrap.user.nickname %></p>
+            </div>
+          </div>
+        </div>
+        <div class="px-2">
+          <p class="focus:outline-none text-sm leading-5 py-4 text-gray-600"><%= scrap.content %></p>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/scraps/show.html.erb
+++ b/app/views/scraps/show.html.erb
@@ -1,0 +1,18 @@
+<div class="space-y-6 w-3/4 max-w-lg">
+  <label class="block text-xl font-bold text-gray-700">学習ログ詳細</label>
+  <div class="items-center justify-center">
+      <div tabindex="0" aria-label="card 1" class="focus:outline-none mb-7 bg-white p-6 shadow rounded">
+        <div class="flex items-center border-b border-gray-200 pb-6">
+          <div class="flex items-start justify-between w-full">
+            <div class="pl-3">
+              <p class="focus:outline-none text-lg font-medium leading-5 text-gray-800"><%= link_to @scrap.title, scrap_path(@scrap) %></p>
+              <p class="focus:outline-none text-sm leading-normal pt-2 text-gray-500">by <%= @scrap.user.nickname %></p>
+            </div>
+          </div>
+        </div>
+        <div class="px-2">
+          <p class="focus:outline-none text-sm leading-5 py-4 text-gray-600"><%= @scrap.content %></p>
+        </div>
+      </div>
+  </div>
+</div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -5,12 +5,18 @@
       <ul class="flex flex-col mt-4 md:flex-row md:space-x-8 md:mt-0 md:text-sm md:font-medium">
         <% if current_user %>
           <li>
+            <%= link_to "ログ一覧", scraps_path, class: "block py-2 pr-4 pl-3 text-gray-400 hover:text-white border-b border-gray-700 hover:bg-gray-700 md:hover:bg-transparent md:border-0 md:hover:text-blue-white md:p-0" %>
+          </li>
+          <li>
             <%= link_to "ログ投稿", new_scrap_path, class: "block py-2 pr-4 pl-3 text-gray-400 hover:text-white border-b border-gray-700 hover:bg-gray-700 md:hover:bg-transparent md:border-0 md:hover:text-blue-white md:p-0" %>
           </li>
           <li>
             <%= button_to "ログアウト", destroy_user_session_path, class: "block py-2 pr-4 pl-3 text-gray-400 hover:text-white border-b border-gray-700 hover:bg-gray-700 md:hover:bg-transparent md:border-0 md:hover:text-blue-white md:p-0", method: :delete %>
           </li>
         <% else %>
+          <li>
+            <%= link_to "ログ一覧", scraps_path, class: "block py-2 pr-4 pl-3 text-gray-400 hover:text-white border-b border-gray-700 hover:bg-gray-700 md:hover:bg-transparent md:border-0 md:hover:text-blue-white md:p-0" %>
+          </li>
           <li>
             <%= link_to "ユーザー登録", new_user_registration_path, class: "block py-2 pr-4 pl-3 text-gray-400 hover:text-white border-b border-gray-700 hover:bg-gray-700 md:hover:bg-transparent md:border-0 md:hover:text-blue-white md:p-0" %>
           </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,5 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root 'home#top'
-  resources :scraps, only: %i[new create show]
+  resources :scraps, only: %i[new create show index]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,5 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root 'home#top'
-  resources :scraps, only: %i[new create]
+  resources :scraps, only: %i[new create show]
 end

--- a/spec/requests/scraps_spec.rb
+++ b/spec/requests/scraps_spec.rb
@@ -3,7 +3,25 @@
 require 'rails_helper'
 
 describe 'Scraps', type: :request do
-  before { @user = create(:user) }
+  before do
+    @user = create(:user) 
+    @scrap = create(:scrap) 
+  end
+  describe 'GET /scraps/id' do
+    context 'ログインしていない場合' do
+      it 'HTTPステータス200を返す' do
+        get "/scraps/#{@scrap.id}"
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'ログイン済みの場合' do
+      it 'HTTPステータス200を返す' do
+        get "/scraps/#{@scrap.id}"
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
   describe 'GET /scraps/new' do
     context 'ログインしていない場合' do
       it 'HTTPステータス302を返す' do

--- a/spec/requests/scraps_spec.rb
+++ b/spec/requests/scraps_spec.rb
@@ -4,8 +4,24 @@ require 'rails_helper'
 
 describe 'Scraps', type: :request do
   before do
-    @user = create(:user) 
-    @scrap = create(:scrap) 
+    @user = create(:user)
+    @scrap = create(:scrap)
+  end
+  describe 'GET /scraps' do
+    context 'ログインしていない場合' do
+      it 'HTTPステータス200を返す' do
+        get '/scraps'
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'ログイン済みの場合' do
+      it 'HTTPステータス200を返す' do
+        sign_in @user
+        get '/scraps'
+        expect(response).to have_http_status(200)
+      end
+    end
   end
   describe 'GET /scraps/id' do
     context 'ログインしていない場合' do

--- a/spec/system/scraps_spec.rb
+++ b/spec/system/scraps_spec.rb
@@ -7,6 +7,7 @@ describe 'Scrap', type: :system do
     driven_by :rack_test
     @user = create(:user)
     @scrap = create(:scrap, user_id: @user.id)
+    @scrap2 = create(:scrap, title: 'テストタイトル2', content: 'テスト本文2', user_id: @user.id)
   end
 
   let(:title) { 'テストタイトル' }
@@ -36,7 +37,7 @@ describe 'Scrap', type: :system do
       context '正常系' do
         it 'Scrapを作成できる' do
           expect { subject }.to change { Scrap.count }.by(1)
-          expect(current_path).to eq('/')
+          expect(current_path).to eq('/scraps')
           expect(page).to have_content('記録しました')
         end
       end
@@ -58,11 +59,32 @@ describe 'Scrap', type: :system do
   end
 
   describe 'スクラップ詳細機能の検証' do
-    before { visit "scraps/#{@scrap.id}"}
+    before { visit "scraps/#{@scrap.id}" }
     it '詳細データが表示される' do
-      expect(page).to have_content("テストタイトル")
-      expect(page).to have_content("テスト本文")
+      expect(page).to have_content('テストタイトル')
+      expect(page).to have_content('テスト本文')
       expect(page).to have_content(@user.nickname)
+    end
+  end
+
+  describe 'スクラップ一覧機能の検証' do
+    before { visit '/scraps' }
+
+    it '1件目のScrapが表示される' do
+      expect(page).to have_content('テストタイトル')
+      expect(page).to have_content('テスト本文')
+      expect(page).to have_content(@user.nickname)
+    end
+
+    it '2件目のScrapが表示される' do
+      expect(page).to have_content('テストタイトル2')
+      expect(page).to have_content('テスト本文2')
+      expect(page).to have_content(@user.nickname)
+    end
+
+    it 'タイトルをクリックすると詳細ページへ遷移する' do
+      click_link 'テストタイトル'
+      expect(current_path).to eq("/scraps/#{@scrap.id}")
     end
   end
 end

--- a/spec/system/scraps_spec.rb
+++ b/spec/system/scraps_spec.rb
@@ -6,6 +6,7 @@ describe 'Scrap', type: :system do
   before do
     driven_by :rack_test
     @user = create(:user)
+    @scrap = create(:scrap, user_id: @user.id)
   end
 
   let(:title) { 'テストタイトル' }
@@ -53,6 +54,15 @@ describe 'Scrap', type: :system do
           end
         end
       end
+    end
+  end
+
+  describe 'スクラップ詳細機能の検証' do
+    before { visit "scraps/#{@scrap.id}"}
+    it '詳細データが表示される' do
+      expect(page).to have_content("テストタイトル")
+      expect(page).to have_content("テスト本文")
+      expect(page).to have_content(@user.nickname)
     end
   end
 end


### PR DESCRIPTION
# 対応するissue
Close #6 

# 概要
- スクラップ一覧/詳細機能

# UI の変更
[![Image from Gyazo](https://i.gyazo.com/fa59961e686d0f50d55b46b935dfd910.gif)](https://gyazo.com/fa59961e686d0f50d55b46b935dfd910)


# 実装の詳細 / 仕様
- [x] ヘッダーからログ一覧で遷移できる
- [x] 一覧のタイトルから詳細へ遷移できる
- [x] バリデーション
- [x] テスト

# その他
- 特になし