### PR TITLE
スクラップ編集/更新機能の実装

### DIFF
--- a/app/controllers/scraps_controller.rb
+++ b/app/controllers/scraps_controller.rb
@@ -23,7 +23,23 @@ class ScrapsController < ApplicationController
       redirect_to scraps_path
     else
       flash[:alert] = '記録に失敗しました'
-      render :new
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    @scrap = Scrap.find_by(id: params[:id])
+  end
+
+  def update
+    @scrap = Scrap.find_by(id: params[:id])
+
+    if @scrap.update(scrap_params)
+      flash[:notice] = '記録を更新しました'
+      redirect_to scraps_path
+    else
+      flash[:alert] = '記録の更新に失敗しました'
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   validates :nickname, presence: true, length: { maximum: 20 }
+
+  def owns?(resource)
+    id == resource.user_id
+  end
 end

--- a/app/views/scraps/edit.html.erb
+++ b/app/views/scraps/edit.html.erb
@@ -1,0 +1,22 @@
+<%= form_with model: @scrap, class: "space-y-6 w-3/4 max-w-lg" do |f| %>
+    <label class="block text-xl font-bold text-gray-700">スクラップを更新する</label>
+    <div class="mt-1">
+      <label class="text-gray-700 text-lg">
+        タイトル
+      </label>
+      <%= f.text_field :title, value: @scrap.title, class: "shadow-sm focus:ring-indigo-500 focus:border-indigo-500 mt-1 block w-full sm:text-sm placeholder-gray-400 border border-gray-300 rounded-md", placeholder: "Railsチュートリアル1章を完了" %>
+    </div>
+    <div class="mt-1">
+      <label class="text-gray-700 text-lg">
+        本文
+      </label>
+      <%= f.text_area :content,value: @scrap.content,rows: "5", class: "shadow-sm focus:ring-indigo-500 focus:border-indigo-500 mt-1 block w-full sm:text-sm placeholder-gray-400 border border-gray-300 rounded-md", placeholder: "環境構築を無事に終えることができた！" %>
+    </div>
+    <p class="mt-2 text-sm text-gray-500">
+      学習したこと、開発したことを記録しましょう。<br>
+      参考にしたサイトがあればURLを書いておくことをオススメします。
+    </p>
+    <div class="px-4 py-3 text-right sm:px-6">
+      <%= f.submit "ログを更新", class: "inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
+    </div>
+  <% end %>

--- a/app/views/scraps/index.html.erb
+++ b/app/views/scraps/index.html.erb
@@ -11,8 +11,26 @@
             </div>
           </div>
         </div>
+        <div class="flex justify-between">
         <div class="px-2">
           <p class="focus:outline-none text-sm leading-5 py-4 text-gray-600"><%= scrap.content %></p>
+        </div>
+        <div class="flex mt-3">
+        <div class="px-2">
+          <% if current_user&.owns?(scrap) %>
+          <button type="button" class="text-white bg-gray-800 hover:bg-gray-900 focus:outline-none focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 dark:bg-gray-800 dark:hover:bg-gray-700 dark:focus:ring-gray-700 dark:border-gray-700">
+            <%= link_to '編集する', edit_scrap_path(scrap) %>
+          </button>
+          <% end %>
+        </div>
+        <div class="px-2">
+        <% if current_user&.owns?(scrap) %>
+        <button type="button" class="focus:outline-none text-white bg-yellow-400 hover:bg-yellow-500 focus:ring-4 focus:ring-yellow-300 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 dark:focus:ring-yellow-900">
+          <%= link_to '削除する', "/" %>
+        </button>
+        <% end %>
+        </div>
+      </div>
         </div>
       </div>
     <% end %>

--- a/app/views/scraps/new.html.erb
+++ b/app/views/scraps/new.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: @scrap, class: "space-y-6 w-3/4 max-w-lg" do |f| %>
-  <label class="block text-3xl font-bold text-gray-700">スクラップを記録する</label>
+  <label class="block text-xl font-bold text-gray-700">スクラップを更新する</label>
   <div class="mt-1">
     <label class="text-gray-700 text-lg">
       タイトル

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,5 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root 'home#top'
-  resources :scraps, only: %i[new create show index]
+  resources :scraps
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -57,4 +57,20 @@ describe User do
       end
     end
   end
+
+  describe '#owns?' do
+    let(:user) { create(:user) }
+    let(:scrap) { create(:scrap, user: user) }
+    let(:other_user) { create(:user) }
+    context 'ユーザのScrapである場合' do
+      it 'trueを返す' do
+        expect(user.owns?(scrap)).to be true
+      end
+    end
+    context 'ユーザのScrapではない場合' do
+      it 'ユーザがリソースを所有していない場合はfalseを返す' do
+        expect(other_user.owns?(scrap)).to be false
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -60,7 +60,7 @@ describe User do
 
   describe '#owns?' do
     let(:user) { create(:user) }
-    let(:scrap) { create(:scrap, user: user) }
+    let(:scrap) { create(:scrap, user:) }
     let(:other_user) { create(:user) }
     context 'ユーザのScrapである場合' do
       it 'trueを返す' do

--- a/spec/requests/scraps_spec.rb
+++ b/spec/requests/scraps_spec.rb
@@ -64,4 +64,20 @@ describe 'Scraps', type: :request do
       end
     end
   end
+
+  describe 'GET /scraps/id/edit' do
+    context 'ログインしていない場合' do
+      it 'HTTPステータス302を返す' do
+        get "/scraps/#{@scrap.id}/edit"
+        expect(response).to have_http_status(302)
+      end
+    end
+    context 'ログイン済みの場合' do
+      before { sign_in @user }
+      it 'HTTPステータス200を返す' do
+        get "/scraps/#{@scrap.id}/edit"
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
 end

--- a/spec/system/scraps_spec.rb
+++ b/spec/system/scraps_spec.rb
@@ -100,7 +100,7 @@ describe 'Scrap', type: :system do
         it '編集するボタンが表示されない' do
           sign_in other_user
           visit '/scraps'
-          expect(page).not_to have_content("編集する")
+          expect(page).not_to have_content('編集する')
         end
       end
     end

--- a/spec/system/scraps_spec.rb
+++ b/spec/system/scraps_spec.rb
@@ -70,21 +70,105 @@ describe 'Scrap', type: :system do
   describe 'スクラップ一覧機能の検証' do
     before { visit '/scraps' }
 
-    it '1件目のScrapが表示される' do
-      expect(page).to have_content('テストタイトル')
-      expect(page).to have_content('テスト本文')
-      expect(page).to have_content(@user.nickname)
-    end
+    context '正常系' do
+      it '1件目のScrapが表示される' do
+        expect(page).to have_content('テストタイトル')
+        expect(page).to have_content('テスト本文')
+        expect(page).to have_content(@user.nickname)
+      end
 
-    it '2件目のScrapが表示される' do
-      expect(page).to have_content('テストタイトル2')
-      expect(page).to have_content('テスト本文2')
-      expect(page).to have_content(@user.nickname)
-    end
+      it '2件目のScrapが表示される' do
+        expect(page).to have_content('テストタイトル2')
+        expect(page).to have_content('テスト本文2')
+        expect(page).to have_content(@user.nickname)
+      end
 
-    it 'タイトルをクリックすると詳細ページへ遷移する' do
-      click_link 'テストタイトル'
-      expect(current_path).to eq("/scraps/#{@scrap.id}")
+      it 'タイトルをクリックすると詳細ページへ遷移する' do
+        click_link 'テストタイトル'
+        expect(current_path).to eq("/scraps/#{@scrap.id}")
+      end
+
+      it '編集するを押下すると編集ページに遷移できる' do
+        sign_in @user
+        visit '/scraps'
+        all('a', text: '編集する').last.click
+        expect(current_path).to eq("/scraps/#{@scrap.id}/edit")
+      end
+
+      context 'ログインユーザーではない時' do
+        let(:other_user) { create(:user) }
+        it '編集するボタンが表示されない' do
+          sign_in other_user
+          visit '/scraps'
+          expect(page).not_to have_content("編集する")
+        end
+      end
+    end
+  end
+
+  describe 'スクラップ編集機能の検証' do
+    before { visit "/scraps/#{@scrap.id}/edit" }
+    context 'ログインしていない場合' do
+      it 'ログインページにリダイレクトされる' do
+        expect(current_path).to eq('/users/sign_in')
+        expect(page).to have_content('ログインしてください。')
+      end
+    end
+    context 'ログイン済みの場合' do
+      before do
+        sign_in @user
+        visit "/scraps/#{@scrap.id}/edit"
+      end
+
+      it 'ログインページにリダイレクトされない' do
+        expect(current_path).not_to eq('/users/sign_in')
+      end
+
+      subject do
+        fill_in 'scrap_title', with: "#{title}hoge"
+        fill_in 'scrap_content', with: "#{content}hoge"
+        click_button 'ログを更新'
+      end
+
+      context '正常系' do
+        it 'Scrapが更新される' do
+          original_title = @scrap.title
+          original_content = @scrap.content
+
+          subject
+
+          updated_scrap = Scrap.find(@scrap.id)
+
+          expect(updated_scrap.title).to eq("#{original_title}hoge")
+          expect(updated_scrap.content).to eq("#{original_content}hoge")
+        end
+
+        it '一覧ページに遷移される' do
+          subject
+          expect(current_path).to eq('/scraps')
+        end
+      end
+
+      context '異常系' do
+        subject do
+          fill_in 'scrap_title', with: title.to_s
+          fill_in 'scrap_content', with: content.to_s
+          click_button 'ログを更新'
+        end
+
+        context 'titleが空の場合' do
+          let(:title) { '' }
+          it 'Scrapを作成できない' do
+            subject
+            expect(page).to have_content('記録の更新に失敗しました')
+          end
+
+          it 'フォームに入力していた内容は保持される' do
+            subject
+            expect(page).to have_field('scrap_content', with: @scrap.content)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
# 対応するissue
Close #7 

# 概要
- スクラップ編集/更新機能の実装

# UI の変更
[![Image from Gyazo](https://i.gyazo.com/0838cf2966182a56fd31c11437a3b11c.gif)](https://gyazo.com/0838cf2966182a56fd31c11437a3b11c)

# 実装の詳細 / 仕様
- ログインユーザのスクラップである場合、編集するボタンが表示される
- 編集ページに遷移され、更新できる
- 前回の値が保持されている
- テストの実装

# その他