### PR TITLE
スクラップ削除機能の実装

### DIFF
--- a/app/controllers/scraps_controller.rb
+++ b/app/controllers/scraps_controller.rb
@@ -37,6 +37,15 @@ class ScrapsController < ApplicationController
     end
   end
 
+  def destroy
+    scrap = Scrap.find_by(id: params[:id])
+    if (scrap.user = current_user)
+      scrap.destroy
+      flash[:notice] = '記録が削除されました'
+    end
+    redirect_to scraps_path
+  end
+
   private
 
   def set_scrap

--- a/app/views/scraps/index.html.erb
+++ b/app/views/scraps/index.html.erb
@@ -23,13 +23,6 @@
           </button>
           <% end %>
         </div>
-        <div class="px-2">
-        <% if current_user&.owns?(scrap) %>
-        <button type="button" class="focus:outline-none text-white bg-yellow-400 hover:bg-yellow-500 focus:ring-4 focus:ring-yellow-300 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 dark:focus:ring-yellow-900">
-          <%= link_to '削除する', "/" %>
-        </button>
-        <% end %>
-        </div>
       </div>
         </div>
       </div>

--- a/app/views/scraps/show.html.erb
+++ b/app/views/scraps/show.html.erb
@@ -8,6 +8,11 @@
               <p class="focus:outline-none text-lg font-medium leading-5 text-gray-800"><%= link_to @scrap.title, scrap_path(@scrap) %></p>
               <p class="focus:outline-none text-sm leading-normal pt-2 text-gray-500">by <%= @scrap.user.nickname %></p>
             </div>
+            <% if user_signed_in? %>
+              <% if current_user&.owns?(@scrap) %>
+                <%= button_to "削除する", scrap_path(@scrap), method: :delete, class: "text-sm bg-transparent hover:bg-blue-500 text-blue-700 hover:text-white py-1 px-3 border border-blue-500 hover:border-transparent rounded" %>
+              <% end %>
+            <% end %>
           </div>
         </div>
         <div class="px-2">

--- a/spec/system/scraps_spec.rb
+++ b/spec/system/scraps_spec.rb
@@ -171,4 +171,29 @@ describe 'Scrap', type: :system do
       end
     end
   end
+
+  describe 'スクラップ削除機能の検証' do
+    before { visit "/scraps/#{@scrap.id}" }
+    context 'ログインしていない場合' do
+      it '削除ボタンが表示されない' do
+        expect(page).not_to have_content('削除する')
+      end
+    end
+    context 'ログイン済みの場合' do
+      before do
+        sign_in @user
+        visit "/scraps/#{@scrap.id}"
+      end
+      it '削除ボタンが表示される' do
+        expect(page).to have_content('削除する')
+      end
+
+      it '削除ボタンが正常に動作する' do
+        expect do
+          click_button '削除する'
+          expect(page).to have_content('記録が削除されました')
+        end.to change { Scrap.count }.by(-1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
# 対応するissue
Close #8 

# 概要
- スクラップ削除機能の実装

# UI の変更
[![Image from Gyazo](https://i.gyazo.com/10973b4e4900ffdcc036340cd3bfa958.gif)](https://gyazo.com/10973b4e4900ffdcc036340cd3bfa958) 

# 実装の詳細 / 仕様
- 削除するを押下でスクラップが削除される
- テスト

# その他